### PR TITLE
add a README saying these are autogen and where they come from

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,13 @@
 This repository is for sharing org-wide Github metadata and workflow templates.
 
 Some files (if not all) in this directory get automagically synced to other
-Knative, so when adding new files, make sure to include a note to templates
-about this. The syncing is done by
+Knative, so when adding new files, make sure to include a note below to
+templates about this. The syncing is done by
 [knobots](https://github.com/mattmoor/knobots).
 
+```yaml
+# This file is automagically synced here from github.com/knative-sandbox/.github
+# repo by knobots: https://github.com/mattmoor/knobots and will be overwritten.
 
+```
 

--- a/README.md
+++ b/README.md
@@ -2,4 +2,10 @@
 
 This repository is for sharing org-wide Github metadata and workflow templates.
 
+Some files (if not all) in this directory get automagically synced to other
+Knative, so when adding new files, make sure to include a note to templates
+about this. The syncing is done by
+[knobots](https://github.com/mattmoor/knobots).
+
+
 

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -1,0 +1,6 @@
+# Knative shared Github workflows
+
+Some files (if not all) in this directory get automagically synced here from
+[Knative .github](https://github.com/knative/.github) and will get
+overridden. The syncing is done by
+[knobots](https://github.com/mattmoor/knobots).

--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -1,6 +1,0 @@
-# Knative shared Github workflows
-
-Some files (if not all) in this directory get automagically synced here from
-[Knative .github](https://github.com/knative/.github) and will get
-overridden. The syncing is done by
-[knobots](https://github.com/mattmoor/knobots).

--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file is automagically synced here from github.com/knative-sandbox/.github
+# repo by knobots: https://github.com/mattmoor/knobots
+
 name: Build
 
 on:

--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This file is automagically synced here from github.com/knative-sandbox/.github
-# repo by knobots: https://github.com/mattmoor/knobots
+# repo by knobots: https://github.com/mattmoor/knobots and will be overwritten.
 
 name: Build
 

--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This file is automagically synced here from github.com/knative-sandbox/.github
-# repo by knobots: https://github.com/mattmoor/knobots
+# repo by knobots: https://github.com/mattmoor/knobots and will be overwritten.
 
 name: Test
 

--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file is automagically synced here from github.com/knative-sandbox/.github
+# repo by knobots: https://github.com/mattmoor/knobots
+
 name: Test
 
 on:

--- a/workflow-templates/knative-stale.yaml
+++ b/workflow-templates/knative-stale.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This file is automagically synced here from github.com/knative-sandbox/.github
-# repo by knobots: https://github.com/mattmoor/knobots
+# repo by knobots: https://github.com/mattmoor/knobots and will be overwritten.
 
 name: 'Close stale'
 on:

--- a/workflow-templates/knative-stale.yaml
+++ b/workflow-templates/knative-stale.yaml
@@ -1,3 +1,20 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is automagically synced here from github.com/knative-sandbox/.github
+# repo by knobots: https://github.com/mattmoor/knobots
+
 name: 'Close stale'
 on:
   schedule:

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file is automagically synced here from github.com/knative-sandbox/.github
+# repo by knobots: https://github.com/mattmoor/knobots
+
 name: Code Style
 
 on:

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This file is automagically synced here from github.com/knative-sandbox/.github
-# repo by knobots: https://github.com/mattmoor/knobots
+# repo by knobots: https://github.com/mattmoor/knobots and will be overwritten.
 
 name: Code Style
 

--- a/workflow-templates/knative-verify.yaml
+++ b/workflow-templates/knative-verify.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file is automagically synced here from github.com/knative-sandbox/.github
+# repo by knobots: https://github.com/mattmoor/knobots
+
 name: Verify
 
 on:

--- a/workflow-templates/knative-verify.yaml
+++ b/workflow-templates/knative-verify.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This file is automagically synced here from github.com/knative-sandbox/.github
-# repo by knobots: https://github.com/mattmoor/knobots
+# repo by knobots: https://github.com/mattmoor/knobots and will be overwritten.
 
 name: Verify
 


### PR DESCRIPTION
Currently the workflows show up to repos (like Eventing, and it's easy enough to make manual changes), add a blurp saying where and how the files get in.
@mattmoor can you also add this to list of files to sync?