### PR TITLE
Switch all GitHub actions to use Go 1.14

### DIFF
--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
 
-      - name: Set up Go 1.15.x
+      - name: Set up Go 1.14.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.14.x
         id: go
 
       - name: Check out code

--- a/workflow-templates/knative-verify.yaml
+++ b/workflow-templates/knative-verify.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Verify Deps and Codegen
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.14.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Switch all GitHub actions to use Go 1.14, as we discussed in https://knative.slack.com/archives/CCSNR4FCH/p1598978184060300

/assign @mattmoor 