### PR TITLE
Add golangci-lint action to the code style action.

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -60,3 +60,15 @@ jobs:
               exit 1
           fi
           echo "${{ github.repository }} is formatted correctly."
+
+      - id: golangci_configuration
+        uses: andstor/file-existence-action@v1
+        with:
+          files: .golangci.yaml
+
+      - name: Go Lint
+        if: steps.golangci_configuration.outputs.files_exists == 'true'
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.30
+          only-new-issues: true # for initial defensiveness


### PR DESCRIPTION
This action will only run if a golangci lint configuration is present in the respective repository for us to be able to gradually roll it out.