### PR TITLE
Drop go vet from the actions, it's redundant with linting.

### DIFF
--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -47,8 +47,5 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Vet
-        run: go vet ./...
-
       - name: Build
         run: go build -v ./...


### PR DESCRIPTION
As per title. `golangci-lint` runs `go vet` too and allows us more control over the reported warnings.

/assign @mattmoor 