### PR TITLE
grep returns an exit code when there are no matches 

### DIFF
--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -59,5 +59,5 @@ jobs:
                 tr '\n' ' ')"
 
           echo "Building with tags: ${tags}"
-          go test -vet=off -tags "${tags}" -run=^$ ./... | grep -v "no test"
+          go test -vet=off -tags "${tags}" -run=^$ ./... | grep -v "no test" || true
 


### PR DESCRIPTION
in this case we're fine to ignore it