### PR TITLE
Fix default .wokeignore with *

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -236,7 +236,10 @@ jobs:
 
           # Create a minimal .wokeignore if none already exist.
           if [ ! -f .wokeignore ]; then
-            echo "vendor\nthird_party" > .wokeignore
+            cat > .wokeignore <<EOF
+            vendor/*
+            third_party/*
+          EOF
           fi
 
           echo '::group:: Running woke with reviewdog 🐶 ...'


### PR DESCRIPTION
I added these to a new repo and started seeing it firing on stuff in vendor.

I checked the `woke` repo and their `.wokeignore` file has stuff like `pkg/*`.