### PR TITLE
Fixup the finds to properly exclude vendor et al

### DIFF
--- a/workflow-templates/knative-donotsubmit.yaml
+++ b/workflow-templates/knative-donotsubmit.yaml
@@ -49,10 +49,7 @@ jobs:
           echo '::group:: Running DO NOT SUBMIT with reviewdog 🐶 ...'
           # Don't fail because of grep
           set +o pipefail
-          find . -path './vendor' -prune \
-                 -o -path './third_party' -prune \
-                 -o -path './.github/workflows' -prune \
-                 -o -type f |
+          find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' -not -path './.github/workflows/*' |
           xargs grep -n "DO NOT SUBMIT" |
           reviewdog -efm="%f:%l:%m" \
                 -name="DO NOT SUBMIT" \

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -127,9 +127,7 @@ jobs:
           echo '::group:: Running github.com/client9/misspell with reviewdog 🐶 ...'
           # Don't fail because of misspell
           set +o pipefail
-          find . -path './vendor' -prune \
-                 -o -path './third_party' -prune \
-                 -o -type f |
+          find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' |
           xargs misspell -error |
           reviewdog -efm="%f:%l:%c: %m" \
                 -name="github.com/client9/misspell" \
@@ -159,9 +157,7 @@ jobs:
           echo '::group:: Flagging trailing whitespace with reviewdog 🐶 ...'
           # Don't fail because of grep
           set +o pipefail
-          find . -path './vendor' -prune \
-                 -o -path './third_party' -prune \
-                 -o -type f |
+          find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' |
           xargs grep -nE " +$" |
           reviewdog -efm="%f:%l:%m" \
                 -name="trailing whitespace" \
@@ -191,10 +187,7 @@ jobs:
           echo '::group:: Flagging missing EOF newlines with reviewdog 🐶 ...'
           # Don't fail because of misspell
           set +o pipefail
-          for x in $(find . -path './vendor' -prune \
-                 -o -path './third_party' -prune \
-                 -o -path './.git' -prune \
-                 -o -type f); do
+          for x in $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*'); do
             # Based on https://stackoverflow.com/questions/34943632/linux-check-if-there-is-an-empty-line-at-the-end-of-a-file
             if [[ -f $x && ! ( -s "$x" && -z "$(tail -c 1 $x)" ) ]]; then
               # We add 1 to `wc -l` here because of this limitation (from the man page):


### PR DESCRIPTION
I found that the previous `find` commands were not recursing into `vendor`, but were returning a `./vendor` entry even though it was not a `-type f`.  I found the article below, which gave another alternative and it seems to work where the current command falls short.

The addition of `./vendor` to the list was causing `misspell` to flag spelling errors within files in `vendor/` even though they were not fully enumerated.

See: https://linuxconfig.org/how-to-explicitly-exclude-directory-from-find-command-s-search