### PR TITLE
Codify the relationship between `knative-sandbox/.github` and `knative/.github`

### DIFF
--- a/.github/workflows/check-source-of-truth.yaml
+++ b/.github/workflows/check-source-of-truth.yaml
@@ -1,0 +1,29 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Source of Truth
+
+on:
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: check
+      if: ${{ github.repository != 'knative-sandbox/.github' }}
+      run: |
+        echo "::error::${{ github.repository }} is not the source of truth.  Please send a Pull Request to 'knative-sandbox/.github' instead."
+        exit 1

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,0 +1,32 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: repo-sync
+
+on:
+  schedule:
+  - cron: '0 13 * * 3' # Runs at 13:00 UTC (6am Pacific) on Wed
+
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+    - name: repo-sync
+      uses: wei/git-sync@v2
+      if: ${{ github.repository != 'knative-sandbox/.github' }}
+      with:
+        source_repo: "knative-sandbox/.github"
+        source_branch: "master"
+        destination_repo: "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+        destination_branch: "master"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 This repository is for sharing org-wide Github metadata and workflow templates.
 
-Some files (if not all) in this directory get automagically synced to other
-Knative, so when adding new files, make sure to include a note below to
-templates about this. The syncing is done by
-[knobots](https://github.com/mattmoor/knobots).
+The source of truth for this content is: https://github.com/knative-sandbox/.github,
+which is mirrored to "downstream" `.github` repositories (e.g. `knative/.github`)
+automatically on a [cron](/.github/workflows/sync.yaml).
+
+The workflow files under `workflow-templates/*.yaml` are automatically pulled into
+"downstream" code repositories (e.g. `knative/serving`'s `.github/workflows`) via
+a Pull Request opened each weekday, currently by the [knobots](https://github.com/mattmoor/knobots).
 
 ```yaml
 # This file is automagically synced here from github.com/knative-sandbox/.github


### PR DESCRIPTION

This PR does three things:
1. Update the README to describe the relationship between `knative-sandbox/.github`
  and downstream `.github` repositories.
2. Add a PR check that fails when PRs are opened against downstream `.github` repositories.
3. Add a cron to mirror upstream into downstream.

Fixes: https://github.com/knative-sandbox/.github/issues/38

/hold