### PR TITLE
Suggest not to format the traling formatting arugment if it's the only one

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -214,7 +214,7 @@ jobs:
           # But exclude the `fmt.Errorf` calls since there's no `fmt.Error` and `errors.New` is not
           # as versatile.
           find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' |
-          xargs egrep -nE 't\.(Errorf|Fatalf|Infof|Warnf)\(.*%.",[^,]+)' | grep -v "fmt.Errorf"
+          xargs egrep -nE '\.(Errorf|Fatalf|Infof|Warnf)\(.*%.",[^,]+)' | grep -v "fmt.Errorf"
           reviewdog -efm="%f:%l:%m" \
                 -name="Possibly unnecessary formatting call for tail argument" \
                 -reporter="github-pr-check" \

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -40,7 +40,6 @@ jobs:
           importpath: golang.org/x/tools/cmd/goimports
 
     steps:
-
       - name: Set up Go 1.15.x
         uses: actions/setup-go@v2
         with:
@@ -214,15 +213,21 @@ jobs:
           # have only a single formatting argument and that argument is in the last position.
           # But exclude the `fmt.Errorf` calls since there's no `fmt.Error` and `errors.New` is not
           # as versatile.
-          find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' |
-          xargs egrep -nE '\.(Errorf|Fatalf|Infof|Warnf|Debugf)\(.*%.",[^,]+)' | grep -v 'fmt.Errorf' |
-          reviewdog -efm="%f:%l:%m" \
-                -name='Unnecessary formatting call for tail argument, to fix do e.g. t.Error("Error is:", err)' \
+          fn=$(find . -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)
+          grep -nE '[^.]+\.(Fatalf|Errorf|Warnf|Infof|Debugf)[^\%]+%[^wq]",[^,]+' $fn | grep -v "fmt.Errorf" |
+            while read -r ent ; do
+              file=$(echo $ent | cut -d':' -f 1);
+              line=$(echo $ent | cut -d':' -f 2);
+              ch=$(echo $ent | cut -d':' -f3-);
+              err=$(echo $ch | sed -E 's/([^.]+\.)(Fatal|Error|Warn|Info|Debug)f([^\%]+)(%[^wq]",)([^,]+)/\1\2\3",\5/');
+              echo "$file:$line: Please consider avoiding tail format like this:%0A$err"
+          done |
+          reviewdog -efm="%f:%l: %m" \
+                -name="Redundant Format" \
                 -reporter="github-pr-check" \
                 -filter-mode="added" \
                 -fail-on-error="true" \
                 -level="error"
-
           echo '::endgroup::'
 
       # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -214,9 +214,9 @@ jobs:
           # But exclude the `fmt.Errorf` calls since there's no `fmt.Error` and `errors.New` is not
           # as versatile.
           find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' |
-          xargs egrep -nE '\.(Errorf|Fatalf|Infof|Warnf)\(.*%.",[^,]+)' | grep -v "fmt.Errorf"
+          xargs egrep -nE '\.(Errorf|Fatalf|Infof|Warnf|Debugf)\(.*%.",[^,]+)' | grep -v 'fmt.Errorf' |
           reviewdog -efm="%f:%l:%m" \
-                -name="Possibly unnecessary formatting call for tail argument" \
+                -name='Unnecessary formatting call for tail argument, to fix do e.g. t.Error("Error is:", err)' \
                 -reporter="github-pr-check" \
                 -filter-mode="added" \
                 -fail-on-error="true" \

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -197,6 +197,33 @@ jobs:
 
           echo '::endgroup::'
 
+      - name: Redundant Format
+        shell: bash
+        if: ${{ always() }}
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          cd "${GITHUB_WORKSPACE}" || exit 1
+
+          echo '::group:: Flagging possibly unnecessary format calls for trailing argument with reviewdog 🐶 ...'
+          # Don't fail because of misspell
+          set +o pipefail
+          # For all look for formatting calls and extract the ones that
+          # have only a single formatting argument and that argument is in the last position.
+          # But exclude the `fmt.Errorf` calls since there's no `fmt.Error` and `errors.New` is not
+          # as versatile.
+          find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' |
+          xargs egrep -nE 't\.(Errorf|Fatalf|Infof|Warnf)\(.*%.",[^,]+)' | grep -v "fmt.Errorf"
+          reviewdog -efm="%f:%l:%m" \
+                -name="Possibly unnecessary formatting call for tail argument" \
+                -reporter="github-pr-check" \
+                -filter-mode="added" \
+                -fail-on-error="true" \
+                -level="error"
+
+          echo '::endgroup::'
+
       # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh
       # since their action is not yet released under a stable version.
       - name: Language


### PR DESCRIPTION

for example logger.Warnf("Riding the storm at %v", time.Now()) is just
as good as logger.Warn("Riding the storm at ", time.Now()), but costs
much less at runtime.

/assign mattmoor