### PR TITLE
Run golangci-lint on the entire codebase, not just new lines

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -120,7 +120,6 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.30
-          only-new-issues: true # for initial defensiveness
 
       - name: misspell
         shell: bash


### PR DESCRIPTION
This is currently missing stuff that are not part of the diff but still caused by the PR at hand. We've so far cleaned out all warnings anyway so everything should be assumed to be clean wrt. linting anyway.