### PR TITLE
Make the script more precise and permit for more verbs and edge cases

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -219,7 +219,19 @@ jobs:
               file=$(echo $ent | cut -d':' -f 1);
               line=$(echo $ent | cut -d':' -f 2);
               ch=$(echo $ent | cut -d':' -f3-);
-              err=$(echo $ch | sed -E 's/([^.]+\.)(Fatal|Error|Warn|Info|Debug|Log|Sprint|Print|Fprint)f([^\%]+)(%[^wq]",)([^,]+)/\1\2\3",\5/');
+              err="Unknown printer tool, please file an issue in knative-sandbox/.github and assign to @vagababov: $ch"
+              if echo $ch | grep --quiet -E "^t.(Errorf|Fatalf|Logf)" ; then
+                err=$(echo $ch | sed  -E 's/([^.fm]+t\.)(Fatal|Error|Log)f([^\%]+)( %[^Tq]",)([^,]+)/\1\2\3",\5/')
+                # Not a test. Here we deal with various loggers and fmt helpers.
+              elif echo $ch | grep --quiet "log" ; then
+                # Capture (x)?log(er)?.
+                err=$(echo $ch | sed -E 's/(.*log.*\.)(Print|Fatal|Error|Info|Warn)f([^\%]+)(%[^Tq]",)([^,]+)/\1\2\3",\5/')
+              elif echo $ch | grep --quiet -E "fmt\.Sprintf" ; then
+                # Always space after sprintf
+                err=$(echo $ch | sed -E 's/(fmt\.)(Sprint)f([^%]+) (%s",)([^,]+)/\1\2\3 ",\5/')
+              elif echo $ch | grep --quiet -E "fmt\." ; then  # all other fmt. printers.
+                err=$(echo $ch | sed -E 's/(fmt\.)(Print|Fprint)f([^%]+) (%[^sTxq]",)([^,]+)/\1\2\3",\5/')
+              fi
               echo "$file:$line: Please consider avoiding tail format like this:%0A$err"
           done |
           reviewdog -efm="%f:%l: %m" \


### PR DESCRIPTION
e.g. always leave space for sprintf, but not for printf, which are different

/assign mattmoor