### PR TITLE
Run Github's security checks against our Golang code

### DIFF
--- a/workflow-templates/knative-security.properties.json
+++ b/workflow-templates/knative-security.properties.json
@@ -1,0 +1,5 @@
+{
+    "name": "Knative security workflow",
+    "description": "Runs automated security checks against the codebase.",
+    "iconName": "blender"
+}

--- a/workflow-templates/knative-security.yaml
+++ b/workflow-templates/knative-security.yaml
@@ -1,0 +1,52 @@
+# Copyright 2020 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is automagically synced here from github.com/knative-sandbox/.github
+# repo by knobots: https://github.com/mattmoor/knobots and will be overwritten.
+
+name: 'Security'
+
+on:
+  pull_request:
+    branches: [ 'master', 'release-*' ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    # If this run was triggered by a pull request event, then checkout
+    # the head of the pull request instead of the merge commit.
+    - run: git checkout HEAD^2
+      if: ${{ github.event_name == 'pull_request' }}
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: go
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
As per title. Also see https://github.blog/2020-09-30-code-scanning-is-now-available/. This is the action provided by Github mostly.

Tested here https://github.com/knative/serving/pull/9646.

I debated adding it to the `style` run but :man_shrugging:. Happy to move there if others think I should.

/assign @mattmoor 