### PR TITLE
Security check on push on the main and release branches

### DIFF
--- a/workflow-templates/knative-security.yaml
+++ b/workflow-templates/knative-security.yaml
@@ -18,6 +18,9 @@
 name: 'Security'
 
 on:
+  push:
+    branches: [ 'master', 'release-*' ]
+    
   pull_request:
     branches: [ 'master', 'release-*' ]
 


### PR DESCRIPTION
We're seeing ["Missing analysis for base commit ad2ba89180a73b623cb9784d3e9d1f6f58fb5604"](https://github.com/knative-sandbox/eventing-kafka-broker/pull/268/checks?check_run_id=1224912335)  and that commit is the last commit on the main branch.