### PR TITLE
Exclude wire gen files.

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -64,8 +64,7 @@ jobs:
           -o -path './third_party' -prune
           -o -name '*.pb.go' -prune
           -o -name 'wire_gen.go' -prune
-          -o -type f -name '*.go'
-          -print)
+          -o -type f -name '*.go' -print)
 
       - name: Verify ${{ matrix.tool }}
         shell: bash

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -57,8 +57,15 @@ jobs:
 
       - name: ${{ matrix.tool }} ${{ matrix.options }}
         shell: bash
-        run: |
-          ${{ matrix.tool }} ${{ matrix.options }} -w $(find . -path './vendor' -prune -o -path './third_party' -prune -o -name '*.pb.go' -prune -o -type f -name '*.go' -print)
+        run: >
+          ${{ matrix.tool }} ${{ matrix.options }} -w
+          $(find .
+          -path './vendor' -prune
+          -o -path './third_party' -prune
+          -o -name '*.pb.go' -prune
+          -o -name 'wire_gen.go' -prune
+          -o -type f -name '*.go'
+          -print)
 
       - name: Verify ${{ matrix.tool }}
         shell: bash


### PR DESCRIPTION
Exclude wire generated files, `wire_gen.go`, from style checks.