### PR TITLE
Add top level PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,68 @@
+<!-- Thanks for sending a pull request! -->
+
+# Changes
+
+<!-- 
+Describe your changes here- ideally you can get that description straight from
+your descriptive commit message(s)! 
+
+- :gift: Add new feature
+- :bug: Fix bug
+- :broom: Update or clean up current behavior
+- :wastebasket: Remove feature or internal logic
+-->
+
+-
+-
+-
+
+<!--
+In addition, categorize the changes you're making using the "/kind" Prow command, example:
+
+/kind <kind>
+
+Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance
+
+-->
+/kind <kind>
+
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
+-->
+Fixes #
+
+<!-- Please include the 'why' behind your changes if no issue exists -->
+
+**Release Note**
+
+<!--
+:page_facing_up: If this change has user-visible impact, write a release note in the block
+below. Include the string "action required" if additional action is required of
+users switching to the new release, for example in case of a breaking change.
+
+Write as if you are speaking to users, not other Knative contributors. If this
+change has no user-visible impact, no release-note is needed.
+-->
+```release-note
+
+```
+
+**Docs**
+
+<!--
+:book: If this change has user-visible impact, link to an issue or PR in
+https://github.com/knative/docs.
+
+See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files
+
+Please use the following format for linking documentation:
+- [knative/docs]: <issue or pr link>
+- [Feature Track]: <link>
+- [Usage]: <link>
+- [Other doc]: <link>
+-->
+```docs
+
+```


### PR DESCRIPTION
To better make PRs in all repos, use the PR template by default. All repos that do not define a PR template will use this inside knative-sandbox.