### PR TITLE
Update woke version to 0.4.1

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install Tools
         env:
-          WOKE_VERSION: v0.1.15
+          WOKE_VERSION: v0.4.1
         run: |
           TEMP_PATH="$(mktemp -d)"
           cd $TEMP_PATH


### PR DESCRIPTION
As per title. All repositories have been adjusted to oblige the respective rules, outstanding to merge are:

- [ ] https://github.com/knative/client-contrib
- [ ] https://github.com/knative-sandbox/net-istio
- [ ] https://github.com/knative/community

The respective PRs should merge soon though.

/assign @mattmoor 