### PR TITLE
Add main branch as a target for all actions

### DIFF
--- a/workflow-templates/knative-boilerplate.yaml
+++ b/workflow-templates/knative-boilerplate.yaml
@@ -19,7 +19,7 @@ name: Boilerplate
 
 on:
   pull_request:
-    branches: [ 'master', 'release-*' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
 jobs:
 

--- a/workflow-templates/knative-donotsubmit.yaml
+++ b/workflow-templates/knative-donotsubmit.yaml
@@ -19,7 +19,7 @@ name: Do Not Submit
 
 on:
   pull_request:
-    branches: [ 'master', 'release-*' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
 jobs:
 

--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -19,7 +19,7 @@ name: Build
 
 on:
   pull_request:
-    branches: [ 'master', 'release-*' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
 jobs:
 

--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -20,10 +20,10 @@ name: Test
 on:
 
   push:
-    branches: [ 'master' ]
+    branches: [ 'main', 'master' ]
 
   pull_request:
-    branches: [ 'master', 'release-*' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
 jobs:
 

--- a/workflow-templates/knative-security.yaml
+++ b/workflow-templates/knative-security.yaml
@@ -19,10 +19,10 @@ name: 'Security'
 
 on:
   push:
-    branches: [ 'master', 'release-*' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
   pull_request:
-    branches: [ 'master', 'release-*' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
 jobs:
   analyze:

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -19,7 +19,7 @@ name: Code Style
 
 on:
   pull_request:
-    branches: [ 'master', 'release-*' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
 jobs:
 

--- a/workflow-templates/knative-verify.yaml
+++ b/workflow-templates/knative-verify.yaml
@@ -19,7 +19,7 @@ name: Verify
 
 on:
   pull_request:
-    branches: [ 'master', 'release-*' ]
+    branches: [ 'main', 'master', 'release-*' ]
 
 jobs:
 


### PR DESCRIPTION
Github has changed the default branch to `main` and we want to move all of our repos in the future too.

`sample-controller` sees no actions running on PRs currently due to this for example.

/assign @mattmoor 