### PR TITLE
Add support for git attributes, keep legacy filters for now

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -141,7 +141,12 @@ jobs:
           echo '::group:: Running github.com/client9/misspell with reviewdog 🐶 ...'
           # Don't fail because of misspell
           set +o pipefail
-          find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' |
+	  # Exclude generated and vendored files, plus some legacy
+          # paths until we update all .gitattributes
+          git ls-files |
+	  git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
+	  git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
+	  grep -Ev '^(vendor/|third_party/|.git)' |
           xargs misspell -error |
           reviewdog -efm="%f:%l:%c: %m" \
                 -name="github.com/client9/misspell" \
@@ -164,7 +169,13 @@ jobs:
           echo '::group:: Flagging trailing whitespace with reviewdog 🐶 ...'
           # Don't fail because of grep
           set +o pipefail
-          find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' |
+	  
+	  # Exclude generated and vendored files, plus some legacy
+          # paths until we update all .gitattributes
+          git ls-files |
+	  git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
+	  git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
+	  grep -Ev '^(vendor/|third_party/|.git)' |
           xargs grep -nE " +$" |
           reviewdog -efm="%f:%l:%m" \
                 -name="trailing whitespace" \
@@ -192,7 +203,13 @@ jobs:
           #  - nothing in third_party
           #  - nothing in .git/
           #  - no *.ai (Adobe Illustrator) files.
-          for x in $(find . -type f -not -name '*.ai' -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*'); do
+          LINT_FILES=$(git ls-files |
+	  git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
+	  git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
+	  grep -Ev '^(vendor/|third_party/|\.git)') |
+	  grep -v '\.ai$')
+
+          for x in $LINT_FILES; do
             # Based on https://stackoverflow.com/questions/34943632/linux-check-if-there-is-an-empty-line-at-the-end-of-a-file
             if [[ -f $x && ! ( -s "$x" && -z "$(tail -c 1 $x)" ) ]]; then
               # We add 1 to `wc -l` here because of this limitation (from the man page):

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -141,12 +141,12 @@ jobs:
           echo '::group:: Running github.com/client9/misspell with reviewdog 🐶 ...'
           # Don't fail because of misspell
           set +o pipefail
-	  # Exclude generated and vendored files, plus some legacy
+          # Exclude generated and vendored files, plus some legacy
           # paths until we update all .gitattributes
           git ls-files |
-	  git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
-	  git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
-	  grep -Ev '^(vendor/|third_party/|.git)' |
+          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
+          grep -Ev '^(vendor/|third_party/|.git)' |
           xargs misspell -error |
           reviewdog -efm="%f:%l:%c: %m" \
                 -name="github.com/client9/misspell" \
@@ -169,13 +169,13 @@ jobs:
           echo '::group:: Flagging trailing whitespace with reviewdog 🐶 ...'
           # Don't fail because of grep
           set +o pipefail
-	  
-	  # Exclude generated and vendored files, plus some legacy
+          
+          # Exclude generated and vendored files, plus some legacy
           # paths until we update all .gitattributes
           git ls-files |
-	  git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
-	  git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
-	  grep -Ev '^(vendor/|third_party/|.git)' |
+          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
+          grep -Ev '^(vendor/|third_party/|.git)' |
           xargs grep -nE " +$" |
           reviewdog -efm="%f:%l:%m" \
                 -name="trailing whitespace" \
@@ -199,15 +199,15 @@ jobs:
           # Don't fail because of misspell
           set +o pipefail
           # Lint exclude rule:
-          #  - nothing in vendor/
+                    #  - nothing in vendor/
           #  - nothing in third_party
           #  - nothing in .git/
           #  - no *.ai (Adobe Illustrator) files.
           LINT_FILES=$(git ls-files |
-	  git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
-	  git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
-	  grep -Ev '^(vendor/|third_party/|\.git)') |
-	  grep -v '\.ai$')
+          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
+          grep -Ev '^(vendor/|third_party/|\.git)') |
+          grep -v '\.ai$')
 
           for x in $LINT_FILES; do
             # Based on https://stackoverflow.com/questions/34943632/linux-check-if-there-is-an-empty-line-at-the-end-of-a-file

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -145,7 +145,7 @@ jobs:
           # paths until we update all .gitattributes
           git ls-files |
           git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
-          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ | cut -d: -f1 |
           grep -Ev '^(vendor/|third_party/|.git)' |
           xargs misspell -error |
           reviewdog -efm="%f:%l:%c: %m" \
@@ -174,7 +174,7 @@ jobs:
           # paths until we update all .gitattributes
           git ls-files |
           git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
-          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ | cut -d: -f1 |
           grep -Ev '^(vendor/|third_party/|.git)' |
           xargs grep -nE " +$" |
           reviewdog -efm="%f:%l:%m" \
@@ -205,7 +205,7 @@ jobs:
           #  - no *.ai (Adobe Illustrator) files.
           LINT_FILES=$(git ls-files |
           git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
-          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ | cut -d: -f1 |
           grep -Ev '^(vendor/|third_party/|\.git)') |
           grep -v '\.ai$')
 


### PR DESCRIPTION
# Changes

- 🎁  Switch from using `find` to `git ls-files`, which will only pick up files managed by `git`
- 🧹  Use Git attributes (from `.gitattributes`) to determine which files need linting, so repos can customize the linted files more easily.

/kind cleanup
/kind enhancement