### PR TITLE
Fix missing single quote in knative-style.yaml

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -144,8 +144,8 @@ jobs:
           # Exclude generated and vendored files, plus some legacy
           # paths until we update all .gitattributes
           git ls-files |
-          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
-          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ | cut -d: -f1 |
+          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
           grep -Ev '^(vendor/|third_party/|.git)' |
           xargs misspell -error |
           reviewdog -efm="%f:%l:%c: %m" \
@@ -173,8 +173,8 @@ jobs:
           # Exclude generated and vendored files, plus some legacy
           # paths until we update all .gitattributes
           git ls-files |
-          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
-          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ | cut -d: -f1 |
+          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
           grep -Ev '^(vendor/|third_party/|.git)' |
           xargs grep -nE " +$" |
           reviewdog -efm="%f:%l:%m" \
@@ -199,14 +199,14 @@ jobs:
           # Don't fail because of misspell
           set +o pipefail
           # Lint exclude rule:
-                    #  - nothing in vendor/
+          #  - nothing in vendor/
           #  - nothing in third_party
           #  - nothing in .git/
           #  - no *.ai (Adobe Illustrator) files.
           LINT_FILES=$(git ls-files |
-          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$ | cut -d: -f1 |
-          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$ | cut -d: -f1 |
-          grep -Ev '^(vendor/|third_party/|\.git)') |
+          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          grep -Ev '^(vendor/|third_party/|.git)' |
           grep -v '\.ai$')
 
           for x in $LINT_FILES; do


### PR DESCRIPTION
This patch fixes knative-style.yaml which currently missing single quote.

**Release Note**

```release-note
NONE
```

/cc @evankanderson @n3wscott @mattmoor 
