### PR TITLE
Bump woke version to 0.5.0

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install Tools
         env:
-          WOKE_VERSION: v0.4.1
+          WOKE_VERSION: v0.5.0
         run: |
           TEMP_PATH="$(mktemp -d)"
           cd $TEMP_PATH


### PR DESCRIPTION
To stay somewhat recent, I'm closely following development. All of our repos (modulo the PRs I just sent) are clean. The PRs I had to sent would be caught by the old version too though, so :shrug:.

/assign @mattmoor 