### PR TITLE
Bump golanglint-ci version

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -127,7 +127,7 @@ jobs:
         if: steps.golangci_configuration.outputs.files_exists == 'true'
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.35
+          version: v1.38
 
       - name: misspell
         shell: bash


### PR DESCRIPTION
Bumps golanglint-ci version to [v1.38](https://github.com/golangci/golangci-lint/releases/tag/v1.38.0) to pick up [importas linter](http://github.com/julz/importas) for https://github.com/knative/serving/pull/10885.

/assign @markusthoemmes 