### PR TITLE
Bend sync and release-note actions to run against main

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -29,6 +29,6 @@ jobs:
       if: ${{ github.repository != 'knative-sandbox/.github' }}
       with:
         source_repo: "https://github.com/knative-sandbox/.github.git"
-        source_branch: "master"
+        source_branch: "main"
         destination_repo: "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
-        destination_branch: "master"
+        destination_branch: "main"

--- a/workflow-templates/knative-releasability.yaml
+++ b/workflow-templates/knative-releasability.yaml
@@ -60,7 +60,7 @@ jobs:
           go-version: 1.15.x
 
       - name: Install Dependencies
-        run: GO111MODULE=on go get knative.dev/test-infra/buoy@master
+        run: GO111MODULE=on go get knative.dev/test-infra/buoy@main
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/workflow-templates/knative-release-notes.yaml
+++ b/workflow-templates/knative-release-notes.yaml
@@ -21,9 +21,9 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch? (master)'
+        description: 'Branch? (main)'
         required: true
-        default: 'master'
+        default: 'main'
       start-sha:
         description: 'Starting SHA? (last tag on branch)'
       end-sha:


### PR DESCRIPTION
A few stray occurrences of `master` references we should now be able to drop safely.