### PR TITLE
Remove explicit checkout from security action

### DIFF
--- a/workflow-templates/knative-security.yaml
+++ b/workflow-templates/knative-security.yaml
@@ -37,11 +37,6 @@ jobs:
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

The scanner started barking like

```
Warning: 1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results.
```

So let's comply.