### PR TITLE
Downgrade linter for now since the release ain't available

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -127,7 +127,7 @@ jobs:
         if: steps.golangci_configuration.outputs.files_exists == 'true'
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.38
+          version: v1.37
 
       - name: misspell
         shell: bash


### PR DESCRIPTION
As pointed out by @tcnghia and golangci/golangci-lint#1813.

/assign @julz 