### PR TITLE
Bump Go version to release notes workflow

### DIFF
--- a/workflow-templates/knative-release-notes.yaml
+++ b/workflow-templates/knative-release-notes.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.16.x
 
       - name: Install Dependencies
         run: GO111MODULE=on go get k8s.io/release/cmd/release-notes


### PR DESCRIPTION
https://github.com/kubernetes/release uses
Go 1.16 only features like `os.MkdirTemp`

[1] https://golang.org/pkg/os/#MkdirTemp
