### PR TITLE
Fix build action to actually fail

### DIFF
--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -43,7 +43,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+    - id: go_mod
+      uses: andstor/file-existence-action@v1
+      with:
+        files: go.mod
+
       - name: Build
+        if: ${{ steps.go_mod.outputs.files_exists == 'true' }}
         run: |
           tags="$(grep -I  -r '// +build' . | \
                 grep -v '^./vendor/' | \
@@ -55,5 +61,4 @@ jobs:
                 tr '\n' ' ')"
 
           echo "Building with tags: ${tags}"
-          go test -vet=off -tags "${tags}" -run=^$ ./... | grep -v "no test" || true
-
+          go test -vet=off -tags "${tags}" -run=^$ ./...


### PR DESCRIPTION
Use the file existence action to ensure we're running against a go repo,
excluding website and others.

Remove the `grep -v` since it has weird semantics and is only for
readability. It exits 1 if all lines match.

Remove the `|| true` since it makes this test always pass.