### PR TITLE
Fix indent for andstor/file-existence-action@v1

### DIFF
--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -43,10 +43,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-    - id: go_mod
-      uses: andstor/file-existence-action@v1
-      with:
-        files: go.mod
+      - id: go_mod
+        uses: andstor/file-existence-action@v1
+        with:
+          files: go.mod
 
       - name: Build
         if: ${{ steps.go_mod.outputs.files_exists == 'true' }}


### PR DESCRIPTION
The indent is wrong so it is failing in downstream.
Please refer to:
https://github.com/knative-sandbox/net-istio/actions/runs/834435863
https://github.com/knative-sandbox/net-kourier/actions/runs/834399431

This patch fix it.

/cc @benmoss @n3wscott @markusthoemmes 