### PR TITLE
Bump releasability action to start asserting v0.24

### DIFF
--- a/workflow-templates/knative-releasability.yaml
+++ b/workflow-templates/knative-releasability.yaml
@@ -36,8 +36,8 @@ jobs:
     env:
       #########################################
       #   Update this section each release.   #
-      RELEASE: 'v0.23'
-      SLACK_CHANNEL: 'release-23'
+      RELEASE: 'v0.24'
+      SLACK_CHANNEL: 'release-24'
       #########################################
 
     steps:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

# Changes

As per the release docs https://github.com/knative/release#update-the-knative-releasability-defaults.

/assign @evankanderson 
/assign @vaikas 
/assign @dprotaso 