### PR TITLE
Trigger job on any branch

### DIFF
--- a/workflow-templates/knative-boilerplate.yaml
+++ b/workflow-templates/knative-boilerplate.yaml
@@ -17,9 +17,7 @@
 
 name: Boilerplate
 
-on:
-  pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+on: pull_request
 
 jobs:
 

--- a/workflow-templates/knative-donotsubmit.yaml
+++ b/workflow-templates/knative-donotsubmit.yaml
@@ -17,9 +17,7 @@
 
 name: Do Not Submit
 
-on:
-  pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+on: pull_request
 
 jobs:
 

--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -17,9 +17,7 @@
 
 name: Build
 
-on:
-  pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+on: pull_request
 
 jobs:
 

--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -17,13 +17,7 @@
 
 name: Test
 
-on:
-
-  push:
-    branches: [ 'main', 'master', 'mkdocs' ]
-
-  pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+on: [push, pull_request]
 
 jobs:
 

--- a/workflow-templates/knative-security.yaml
+++ b/workflow-templates/knative-security.yaml
@@ -17,12 +17,7 @@
 
 name: 'Security'
 
-on:
-  push:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
-
-  pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+on: [push, pull_request]
 
 jobs:
   analyze:

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -17,9 +17,7 @@
 
 name: Code Style
 
-on:
-  pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+on: pull_request
 
 jobs:
 

--- a/workflow-templates/knative-verify.yaml
+++ b/workflow-templates/knative-verify.yaml
@@ -17,9 +17,7 @@
 
 name: Verify
 
-on:
-  pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+on: pull_request
 
 jobs:
 


### PR DESCRIPTION
Current github actions are triggered on some specific branches - `main`,
`master`, `release-*` and `mkdocs`.
There should have no problem even when the actions should run on any
branches.

ref: https://docs.github.com/en/actions/reference/events-that-trigger-workflows

/cc @evankanderson 