### PR TITLE
Remove master branch from trigger

### DIFF
--- a/workflow-templates/knative-boilerplate.yaml
+++ b/workflow-templates/knative-boilerplate.yaml
@@ -19,7 +19,7 @@ name: Boilerplate
 
 on:
   pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+    branches: [ 'main', 'release-*', 'mkdocs' ]
 
 jobs:
 

--- a/workflow-templates/knative-donotsubmit.yaml
+++ b/workflow-templates/knative-donotsubmit.yaml
@@ -19,7 +19,7 @@ name: Do Not Submit
 
 on:
   pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+    branches: [ 'main', 'release-*', 'mkdocs' ]
 
 jobs:
 

--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -19,7 +19,7 @@ name: Build
 
 on:
   pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+    branches: [ 'main', 'release-*', 'mkdocs' ]
 
 jobs:
 

--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -20,10 +20,10 @@ name: Test
 on:
 
   push:
-    branches: [ 'main', 'master', 'mkdocs' ]
+    branches: [ 'main', 'mkdocs' ]
 
   pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+    branches: [ 'main', 'release-*', 'mkdocs' ]
 
 jobs:
 

--- a/workflow-templates/knative-security.yaml
+++ b/workflow-templates/knative-security.yaml
@@ -19,10 +19,10 @@ name: 'Security'
 
 on:
   push:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+    branches: [ 'main', 'release-*', 'mkdocs' ]
 
   pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+    branches: [ 'main', 'release-*', 'mkdocs' ]
 
 jobs:
   analyze:

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -19,7 +19,7 @@ name: Code Style
 
 on:
   pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+    branches: [ 'main', 'release-*', 'mkdocs' ]
 
 jobs:
 

--- a/workflow-templates/knative-verify.yaml
+++ b/workflow-templates/knative-verify.yaml
@@ -19,7 +19,7 @@ name: Verify
 
 on:
   pull_request:
-    branches: [ 'main', 'master', 'release-*', 'mkdocs' ]
+    branches: [ 'main', 'release-*', 'mkdocs' ]
 
 jobs:
 


### PR DESCRIPTION
This patch removes `master` branch from branch to trigger.
All Knative projects should have deprecated `master` branch.