### PR TITLE
Fix merge step of unit test action

### DIFF
--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -50,6 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: Merge upstream
+        if: github.event_name == 'pull_request'
         run: |
           git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream ${{ github.base_ref }}


### PR DESCRIPTION
This PR limits `merge` step to `pull_request` event only, otherwise when executed on push to `main` it fails due to missing `github.base_ref`.


# Changes
- :bug: Fix merge step of unit test action

Fixes #127 

