### PR TITLE
Bump releasability action to start asserting v0.25

### DIFF
--- a/workflow-templates/knative-releasability.yaml
+++ b/workflow-templates/knative-releasability.yaml
@@ -36,8 +36,8 @@ jobs:
     env:
       #########################################
       #   Update this section each release.   #
-      RELEASE: 'v0.24'
-      SLACK_CHANNEL: 'release-24'
+      RELEASE: 'v0.25'
+      SLACK_CHANNEL: 'release-25'
       #########################################
 
     steps:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- As per the release docs https://github.com/knative/release#update-the-knative-releasability-defaults.
