### PR TITLE
Bump the versions of our linting tools

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install Tools
         env:
-          WOKE_VERSION: v0.8.0
+          WOKE_VERSION: v0.13.0
         run: |
           TEMP_PATH="$(mktemp -d)"
           cd $TEMP_PATH
@@ -127,7 +127,7 @@ jobs:
         if: steps.golangci_configuration.outputs.files_exists == 'true'
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.40
+          version: v1.42
 
       - name: misspell
         shell: bash


### PR DESCRIPTION
Newer is always better, right? Did a quick run through all repos with `woke` because the bump is quite big. No errors found.

/assign @julz 