### PR TITLE
Install misspell via installation script to avoid go get

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -110,7 +110,7 @@ jobs:
           echo '::endgroup::'
 
           echo '::group:: Installing misspell ... https://github.com/client9/misspell'
-          go get github.com/client9/misspell/cmd/misspell
+          curl -sfL https://git.io/misspell | sh -s -- -b "${TEMP_PATH}" 2>&1
           echo '::endgroup::'
 
           echo '::group:: Installing woke ... https://github.com/get-woke/woke'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

This avoids `golangci-lint` running into cache conflicts via https://github.com/golangci/golangci-lint-action/issues/23.

/assign @julz 