### PR TITLE
Fix git identity in `Merge upstream` step

### DIFF
--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -52,6 +52,12 @@ jobs:
       - name: Merge upstream
         if: github.event_name == 'pull_request'
         run: |
+          if ! git config user.name > /dev/null; then
+            git config user.name "John Doe"
+          fi
+          if ! git config user.email > /dev/null; then
+            git config user.email "johndoe@localhost"
+          fi
           git remote add upstream https://github.com/${{ github.repository }}.git
           git fetch upstream ${{ github.base_ref }}
           git pull --no-rebase --no-commit upstream ${{ github.base_ref }}


### PR DESCRIPTION
# Changes

Fix git identity in `Merge upstream` step.
For non-members of knative it seems these values are not set.

Fixes #137
