### PR TITLE
Change 'go get' to 'go install'

### DIFF
--- a/workflow-templates/knative-boilerplate.yaml
+++ b/workflow-templates/knative-boilerplate.yaml
@@ -61,7 +61,7 @@ jobs:
           echo '::endgroup::'
 
           echo '::group:: Installing boilerplate-check ... https://github.com/mattmoor/boilerplate-check'
-          go get github.com/mattmoor/boilerplate-check/cmd/boilerplate-check
+          go install github.com/mattmoor/boilerplate-check/cmd/boilerplate-check@latest
           echo '::endgroup::'
 
           echo "${TEMP_PATH}" >> $GITHUB_PATH

--- a/workflow-templates/knative-releasability.yaml
+++ b/workflow-templates/knative-releasability.yaml
@@ -66,7 +66,7 @@ jobs:
           go-version: 1.17.x
 
       - name: Install Dependencies
-        run: GO111MODULE=on go get knative.dev/test-infra/buoy@main
+        run: go install knative.dev/test-infra/buoy@main
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/workflow-templates/knative-release-notes.yaml
+++ b/workflow-templates/knative-release-notes.yaml
@@ -44,7 +44,7 @@ jobs:
           go-version: 1.17.x
 
       - name: Install Dependencies
-        run: GO111MODULE=on go get k8s.io/release/cmd/release-notes
+        run: go install k8s.io/release/cmd/release-notes@latest
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -37,7 +37,7 @@ jobs:
         - tool: gofmt
           options: -s
         - tool: goimports
-          importpath: golang.org/x/tools/cmd/goimports
+          package: golang.org/x/tools/cmd/goimports@latest
 
     steps:
       - name: Set up Go
@@ -50,10 +50,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Dependencies
-        if: ${{ matrix.importpath != '' }}
+        if: ${{ matrix.package != '' }}
         run: |
           cd $(mktemp -d)
-          GO111MODULE=on go get ${{ matrix.importpath }}
+          go install ${{ matrix.package }}
 
       - name: ${{ matrix.tool }} ${{ matrix.options }}
         shell: bash

--- a/workflow-templates/knative-verify.yaml
+++ b/workflow-templates/knative-verify.yaml
@@ -45,15 +45,11 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        curl -L https://github.com/google/ko/releases/download/v0.6.0/ko_0.6.0_Linux_x86_64.tar.gz | tar xzf - ko
-        chmod +x ./ko
-        sudo mv ko /usr/local/bin
-        go get github.com/google/go-licenses
+        go install github.com/google/ko@latest
+        go install github.com/google/go-licenses@latest
 
-    - name: Check out code onto GOPATH
+    - name: Check out code
       uses: actions/checkout@v2
-      with:
-        path: ./src/knative.dev/${{ github.event.repository.name }}
 
     - name: Update Codegen
       shell: bash


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Change `go get`s to `go install`
- :broom: Float the ko dependency

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind cleanup

Fixes this warning we see everywhere:
```
go get: installing executables with 'go get' in module mode is deprecated.
	Use 'go install pkg@version' instead.
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```