### PR TITLE
Remove GOPATH from knative-verify

### DIFF
--- a/workflow-templates/knative-verify.yaml
+++ b/workflow-templates/knative-verify.yaml
@@ -32,11 +32,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
-    env:
-      GOPATH: ${{ github.workspace }}
-
     steps:
-
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v2
       with:
@@ -54,9 +50,7 @@ jobs:
     - name: Update Codegen
       shell: bash
       run: |
-        pushd ./src/knative.dev/${{ github.event.repository.name }}
         [[ ! -f hack/update-codegen.sh ]] || ./hack/update-codegen.sh
-        popd
 
     - name: Verify
       shell: bash
@@ -68,7 +62,6 @@ jobs:
           sed ':begin;$!N;s/\n/%0A/;tbegin'
         }
 
-        pushd ./src/knative.dev/${{ github.event.repository.name }}
         if [[ -z "$(git status --porcelain)" ]]; then
             echo "${{ github.repository }} up to date."
         else
@@ -81,4 +74,3 @@ jobs:
             echo "${{ github.repository }} is out of date. Please run hack/update-codegen.sh"
             exit 1
         fi
-        popd


### PR DESCRIPTION
It causes binaries to get installed in the repo directory, which then messes up checkout.

In [this run](https://github.com/knative-sandbox/net-kourier/runs/4165607073?check_suite_focus=true#step:4:19) we see the checkout action trying to delete the net-kourier directory, which shouldn't exist yet. It exists because "install deps" was installing these binaries to `/home/runner/work/net-kourier/net-kourier` because that was the set as the `GOPATH` and `go install` says 

```
Executables are installed in the directory named by the GOBIN environment
variable, which defaults to $GOPATH/bin or $HOME/go/bin if the GOPATH
environment variable is not set. Executables in $GOROOT
are installed in $GOROOT/bin or $GOTOOLDIR instead of $GOBIN.
```

@dprotaso @markusthoemmes 