### PR TITLE
Fix tools not being installed in knative-style

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -109,6 +109,7 @@ jobs:
           version: v1.43
 
       - name: Install Tools
+        if: ${{ always() }}
         env:
           WOKE_VERSION: v0.13.0
         run: |


### PR DESCRIPTION
# Changes

- Always install tools in knative-style so that subsequent steps won't fail

/kind bug

Fixes #158

We don't need to fail fast, we can run all the linters, but since this step was missing the `if: always`, it would be skipped which means the other steps are definitely going to fail.

I tested this out here: https://github.com/benmoss/eventing-rabbitmq/runs/4562246793?check_suite_focus=true