### PR TITLE
Bump releasability action to start asserting v1.2

### DIFF
--- a/workflow-templates/knative-releasability.yaml
+++ b/workflow-templates/knative-releasability.yaml
@@ -38,9 +38,9 @@ jobs:
     env:
       #########################################
       #   Update this section each release.   #
-      RELEASE: 'v1.1'
-      MODULE_RELEASE: 'v0.28'
-      SLACK_CHANNEL: 'release-1dot1'
+      RELEASE: 'v1.2'
+      MODULE_RELEASE: 'v0.29'
+      SLACK_CHANNEL: 'release-1dot2'
       #########################################
 
     steps:


### PR DESCRIPTION
# Changes

As per [the docs](https://github.com/knative/release#update-the-knative-releasability-defaults)