### PR TITLE
Bump unicode action to v0.1.1

### DIFF
--- a/.github/workflows/knative-security.yaml
+++ b/.github/workflows/knative-security.yaml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Find Unicode Control Characters
-      uses: pierdipi/unicode-control-characters-action@v0.1.0
+      uses: pierdipi/unicode-control-characters-action@v0.1.1
       with:
         args: -d .
 

--- a/workflow-templates/knative-security.yaml
+++ b/workflow-templates/knative-security.yaml
@@ -50,7 +50,7 @@ jobs:
       uses: github/codeql-action/analyze@v1
 
     - name: Find Unicode Control Characters
-      uses: pierdipi/unicode-control-characters-action@v0.1.0
+      uses: pierdipi/unicode-control-characters-action@v0.1.1
       with:
         args: -d .
 


### PR DESCRIPTION
[Release notes:](https://github.com/pierDipi/unicode-control-characters-action/releases/tag/v0.1.1)

- Log the position of the invalid character

/assign @dprotaso 