### PR TITLE
ignore .svg for woke

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -246,6 +246,7 @@ jobs:
             cat > .wokeignore <<EOF
             vendor/*
             third_party/*
+            *.svg
           EOF
           fi
 


### PR DESCRIPTION
woke reviewdog is giving a false negative on an picture/image file
Is blocking this PR https://github.com/knative/docs/pull/4747

```
  Raw Output:
  Error: ages/home-images/dkblue_event_intergrations_icon.svg:2842:40: [error] `GUYS` may be insensitive, use `folks`, `people`, `you all`, `y'all`, `yinz` instead
  Error: [woke] reported by reviewdog 🐶
  Error:  `gUyS` may be insensitive, use `folks`, `people`, `you all`, `y'all`, `yinz` instead
```