### PR TITLE
ignore newline EOF for svg

### DIFF
--- a/workflow-templates/knative-style.yaml
+++ b/workflow-templates/knative-style.yaml
@@ -211,7 +211,8 @@ jobs:
           git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
           git check-attr --stdin ignore-lint | grep -Ev ': (set|true)$' | cut -d: -f1 |
           grep -Ev '^(vendor/|third_party/|.git)' |
-          grep -v '\.ai$')
+          grep -v '\.ai$' |
+          grep -v '\.svg$')
 
           for x in $LINT_FILES; do
             # Based on https://stackoverflow.com/questions/34943632/linux-check-if-there-is-an-empty-line-at-the-end-of-a-file


### PR DESCRIPTION
We have svg image files in the website repo, and need to ignore this files

cc @gabo1208 