### PR TITLE
Update knative-releasability.yaml for Knative 1.3 release

### DIFF
--- a/workflow-templates/knative-releasability.yaml
+++ b/workflow-templates/knative-releasability.yaml
@@ -38,9 +38,9 @@ jobs:
     env:
       #########################################
       #   Update this section each release.   #
-      RELEASE: 'v1.2'
-      MODULE_RELEASE: 'v0.29'
-      SLACK_CHANNEL: 'release-1dot2'
+      RELEASE: 'v1.3'
+      MODULE_RELEASE: 'v0.30'
+      SLACK_CHANNEL: 'release-1dot3'
       #########################################
 
     steps:


### PR DESCRIPTION
# Changes
- Prepare for v1.3 Knative Release as per [release instructions](https://github.com/knative/release#14-days-prior-to-the-release)