### PR TITLE
Remove the matrix from some tests.

### DIFF
--- a/workflow-templates/knative-go-build.yaml
+++ b/workflow-templates/knative-go-build.yaml
@@ -25,19 +25,17 @@ jobs:
 
   build:
     name: Build
-    strategy:
-      matrix:
-        go-version: [1.17.x]
-        platform: [ubuntu-latest]
-
-    runs-on: ${{ matrix.platform }}
+    # Please don't use matrixes for this action. It is marked as required in branchprotector.
+    # Everytime you modify the matrix, GitHub generates a new status context which needs to be 
+    # updated in prow.
+    runs-on: ubuntu-latest
 
     steps:
 
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.17.x
         id: go
 
       - name: Check out code

--- a/workflow-templates/knative-go-test.yaml
+++ b/workflow-templates/knative-go-test.yaml
@@ -29,19 +29,17 @@ jobs:
 
   test:
     name: Unit Tests
-    strategy:
-      matrix:
-        go-version: [1.17.x]
-        platform: [ubuntu-latest]
-
-    runs-on: ${{ matrix.platform }}
+    # Please don't use matrixes for this action. It is marked as required in branchprotector.
+    # Everytime you modify the matrix, GitHub generates a new status context which needs to be 
+    # updated in prow.
+    runs-on: ubuntu-latest
 
     steps:
 
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.17.x
         id: go
 
       - name: Check out code

--- a/workflow-templates/knative-verify.yaml
+++ b/workflow-templates/knative-verify.yaml
@@ -25,18 +25,16 @@ jobs:
 
   verify:
     name: Verify Deps and Codegen
-    strategy:
-      matrix:
-        go-version: [1.17.x]
-        platform: [ubuntu-latest]
-
-    runs-on: ${{ matrix.platform }}
+    # Please don't use matrixes for this action. It is marked as required in branchprotector.
+    # Everytime you modify the matrix, GitHub generates a new status context which needs to be 
+    # updated in prow.
+    runs-on: ubuntu-latest
 
     steps:
-    - name: Set up Go ${{ matrix.go-version }}
+    - name: Set up Go 1.17.x
       uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: 1.17.x
       id: go
 
     - name: Install Dependencies


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
/cc @dprotaso @chizhg  

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

Part of: https://github.com/knative/test-infra/issues/2985

- Reworking the simpler github actions to allow prow to mark it as required.
- The github treates each matrix permutation as a unique status so when we move to go 1.18 the status that we are tracking for 1.17 
will now be different. Current test status is `"Build (1.17.x, ubuntu-latest)"`
- Once this is merged, can a repo admin run add the new test briefly and run `gh api 
repos/knative/serving/branches/main/protection/required_status_checks/contexts`

/kind enhancement


